### PR TITLE
CMake and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,75 @@
+name: Build
+
+on: [push, pull_request]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  win-build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Environment
+      run: |
+        echo ${env:BOOST_ROOT_1_72_0}
+        echo "BOOST_ROOT=${env:BOOST_ROOT_1_72_0}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        #choco install boost-msvc-14.2
+
+    - name: Build
+      run: |
+        cmake -B build
+        cmake --build build -j2 --config ${env:BUILD_TYPE}
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: win-numero
+        path: build/${{env.BUILD_TYPE}}/numero.exe
+
+  linux-build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install libboost-date-time-dev libboost-program-options-dev
+
+    - name: Build
+      run: |
+        cmake -B build
+        cmake --build build -j2 --config ${env:BUILD_TYPE}
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux-numero
+        path: build/numero
+
+  mac-build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Environment
+      run: |
+        brew install boost
+
+    - name: Build
+      run: |
+        cmake -B build
+        cmake --build build -j2 --config ${env:BUILD_TYPE}
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: mac-numero
+        path: build/numero
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -72,4 +72,3 @@ jobs:
       with:
         name: mac-numero
         path: build/numero
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build
       run: |
         cmake -B build
-        cmake --build build -j2 --config ${env:BUILD_TYPE}
+        cmake --build build --config ${env:BUILD_TYPE}
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         path: build/${{env.BUILD_TYPE}}/numero.exe
 
   linux-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.16)
 
 set(PROJECT_NAME numero)
 project(${PROJECT_NAME} LANGUAGES CXX)
@@ -10,7 +10,7 @@ if(NOT CMAKE_BUILD_TYPE)
     message(STATUS "Build type not specified: Use Release by default.")
 endif(NOT CMAKE_BUILD_TYPE)
 
-find_package(Boost 1.56 REQUIRED COMPONENTS
+find_package(Boost 1.71 REQUIRED COMPONENTS
              date_time program_options)
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+## SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.13)
+
+set(PROJECT_NAME numero)
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release")
+    message(STATUS "Build type not specified: Use Release by default.")
+endif(NOT CMAKE_BUILD_TYPE)
+
+find_package(Boost 1.56 REQUIRED COMPONENTS
+             date_time program_options)
+
+add_executable(${PROJECT_NAME} ${SRC_FILES})
+target_sources(${PROJECT_NAME}
+    PRIVATE
+        numero/entity.h
+        numero/entity.cpp
+        numero/group.cpp
+        numero/group.h
+        numero/holiday.h
+        numero/holiday.cpp
+        numero/numero.h
+        numero/numero.cpp
+        numero/time_unit.h
+        numero/time_unit.cpp)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED YES)
+
+target_link_libraries(${PROJECT_NAME} Boost::date_time Boost::program_options)


### PR DESCRIPTION
* Basic CMake file
* Github Actions to build on Windows, Linux and macOS

Note that CMake relies on Boost being install in the system, not on the submodule. It appears that it's the recommended way to have a dependency on Boost in the CMake build.

Github Actions will trigger on any push to the repo and on pull requests.